### PR TITLE
Problem in malloc

### DIFF
--- a/src/bin/main.c
+++ b/src/bin/main.c
@@ -175,7 +175,6 @@ int main(int argc, const char* argv[])
 
         if (!strcmp(full_filename, "-")) {
             int             len;
-            int             c;
 
             /* Read a line from stdin. If EOF encountered, continue */
             if (!fgets(file_line_buffer, FILENAME_MAX + 1, stdin)) {


### PR DESCRIPTION
Corrected `char** ... = malloc(n * sizeof(char**))` to `char** ... = malloc(n * sizeof(char*))`. This is not a big issue, since I think that size of all pointers would be the same.
