### PR TITLE
cmake: add GNUInstallDirs option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8)
 
 set (editorconfig_VERSION_MAJOR 0)
 set (editorconfig_VERSION_MINOR 12)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -24,6 +24,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+include(GNUInstallDirs)
+
 set(editorconfig_LIBSRCS
     ec_glob.c
     editorconfig.c
@@ -58,7 +60,7 @@ endif()
 target_link_libraries(editorconfig_static ${PCRE_LIBRARIES})
 
 install(TARGETS editorconfig_shared editorconfig_static
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
Allow multiarch install on FHS systems and GNU style installation
for OS portability.