### PR TITLE
Seperate core libs from EXE by default.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,9 @@ could be used when generating the project file:
 
     -DBUILD_STATICALLY_LINKED_EXE=[ON|OFF]  Default: OFF
     If this option is on, the executable will be linked statically to all
-    libraries. This option is currently only valid for gcc.
+    libraries. On MSVC, this means that EditorConfig will be statically
+    linked to the executable. On GCC, this means all libraries (glibc and 
+    EditorConfig) are statically linked to the executable.
     e.g. cmake -DBUILD_STATICALLY_LINKED_EXE=ON .
 
     -DINSTALL_HTML_DOC=[ON|OFF]             Default: OFF

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,12 +41,6 @@ could be used when generating the project file:
     man pages will be generated.
     e.g. cmake -DBUILD_DOCUMENTATION=OFF .
 
-    -DBUILD_STATICALLY_LINKED_ECC=[ON|OFF]  Default: OFF
-    If this option is on, the executable will link the EditorConfig-core
-    libraries statically. Otherwise, the executable will dynamically link
-    to libeditorconfig.so.
-    e.g. cmake -DBUILD_STATICALLY_LINKED_EXE=OFF .
-
     -DBUILD_STATICALLY_LINKED_EXE=[ON|OFF]  Default: OFF
     If this option is on, the executable will be linked statically to all
     libraries. This option is currently only valid for gcc.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,6 +41,12 @@ could be used when generating the project file:
     man pages will be generated.
     e.g. cmake -DBUILD_DOCUMENTATION=OFF .
 
+    -DBUILD_STATICALLY_LINKED_ECC=[ON|OFF]  Default: OFF
+    If this option is on, the executable will link the EditorConfig-core
+    libraries statically. Otherwise, the executable will dynamically link
+    to libeditorconfig.so.
+    e.g. cmake -DBUILD_STATICALLY_LINKED_EXE=OFF .
+
     -DBUILD_STATICALLY_LINKED_EXE=[ON|OFF]  Default: OFF
     If this option is on, the executable will be linked statically to all
     libraries. This option is currently only valid for gcc.

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -26,6 +26,7 @@
 
 link_directories(${CMAKE_ARCHIVE_OUTPUT_DIR})
 
+set(BUILD_STATICALLY_LINKED_ECC_DEFAULT_VAL OFF)
 # for gcc, BUILD_STATICALLY_LINKED_EXE_DEFAULT_VAL is OFF
 if(CMAKE_COMPILER_IS_GNUCC)
     set(BUILD_STATICALLY_LINKED_EXE_DEFAULT_VAL OFF)
@@ -34,6 +35,9 @@ endif(CMAKE_COMPILER_IS_GNUCC)
 option(BUILD_STATICALLY_LINKED_EXE
     "Link the standard library statically when building the executable.(Only valid for gcc)"
     ${BUILD_STATICALLY_LINKED_EXE_DEFAULT_VAL})
+option(BUILD_STATICALLY_LINKED_ECC
+    "Link the editorconfig libraries statically when building the executable."
+    ${BUILD_STATICALLY_LINKED_ECC_DEFAULT_VAL})
 
 if(CMAKE_COMPILER_IS_GNUCC)
     if(BUILD_STATICALLY_LINKED_EXE)
@@ -47,7 +51,11 @@ set(editorconfig_BINSRCS
 
 # targets
 add_executable(editorconfig_bin ${editorconfig_BINSRCS})
-target_link_libraries(editorconfig_bin editorconfig_static)
+if(BUILD_STATICALLY_LINKED_ECC)
+    target_link_libraries(editorconfig_bin editorconfig_static)
+else(BUILD_STATICALLY_LINKED_ECC)
+    target_link_libraries(editorconfig_bin editorconfig_shared)
+endif(BUILD_STATICALLY_LINKED_ECC)
 set_target_properties(editorconfig_bin PROPERTIES
     OUTPUT_NAME editorconfig
     VERSION

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif(CMAKE_COMPILER_IS_GNUCC)
 
 option(BUILD_STATICALLY_LINKED_EXE
-    "Link the standard library statically when building the executable.(Only valid for gcc)"
+    "Statically link all libraries when building the executable.(Only valid for gcc)"
     ${BUILD_STATICALLY_LINKED_EXE_DEFAULT_VAL})
 
 if(CMAKE_COMPILER_IS_GNUCC)

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif(CMAKE_COMPILER_IS_GNUCC)
 
 option(BUILD_STATICALLY_LINKED_EXE
-    "Statically link all libraries when building the executable.(Only valid for gcc)"
+    "Statically link all libraries when building the executable."
     ${BUILD_STATICALLY_LINKED_EXE_DEFAULT_VAL})
 
 if(CMAKE_COMPILER_IS_GNUCC)

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -26,7 +26,6 @@
 
 link_directories(${CMAKE_ARCHIVE_OUTPUT_DIR})
 
-set(BUILD_STATICALLY_LINKED_ECC_DEFAULT_VAL OFF)
 # for gcc, BUILD_STATICALLY_LINKED_EXE_DEFAULT_VAL is OFF
 if(CMAKE_COMPILER_IS_GNUCC)
     set(BUILD_STATICALLY_LINKED_EXE_DEFAULT_VAL OFF)
@@ -35,15 +34,11 @@ endif(CMAKE_COMPILER_IS_GNUCC)
 option(BUILD_STATICALLY_LINKED_EXE
     "Link the standard library statically when building the executable.(Only valid for gcc)"
     ${BUILD_STATICALLY_LINKED_EXE_DEFAULT_VAL})
-option(BUILD_STATICALLY_LINKED_ECC
-    "Link the editorconfig libraries statically when building the executable."
-    ${BUILD_STATICALLY_LINKED_ECC_DEFAULT_VAL})
 
 if(CMAKE_COMPILER_IS_GNUCC)
     if(BUILD_STATICALLY_LINKED_EXE)
         # Add -static for linker if we want a statically linked executable
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-        set(BUILD_STATICALLY_LINKED_ECC ON)
     endif(BUILD_STATICALLY_LINKED_EXE)
 endif(CMAKE_COMPILER_IS_GNUCC)
 
@@ -52,11 +47,11 @@ set(editorconfig_BINSRCS
 
 # targets
 add_executable(editorconfig_bin ${editorconfig_BINSRCS})
-if(BUILD_STATICALLY_LINKED_ECC)
+if(BUILD_STATICALLY_LINKED_EXE)
     target_link_libraries(editorconfig_bin editorconfig_static)
-else(BUILD_STATICALLY_LINKED_ECC)
+else(BUILD_STATICALLY_LINKED_EXE)
     target_link_libraries(editorconfig_bin editorconfig_shared)
-endif(BUILD_STATICALLY_LINKED_ECC)
+endif(BUILD_STATICALLY_LINKED_EXE)
 set_target_properties(editorconfig_bin PROPERTIES
     OUTPUT_NAME editorconfig
     VERSION

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -43,6 +43,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
     if(BUILD_STATICALLY_LINKED_EXE)
         # Add -static for linker if we want a statically linked executable
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+        set(BUILD_STATICALLY_LINKED_ECC ON)
     endif(BUILD_STATICALLY_LINKED_EXE)
 endif(CMAKE_COMPILER_IS_GNUCC)
 


### PR DESCRIPTION
EditorConifg Core libs should be separated from the main binary by default, and as required by the Fedora packaging guidelines.