### PR TITLE
Build: Seperate core libs from EXE by default.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,9 @@ could be used when generating the project file:
 
     -DBUILD_STATICALLY_LINKED_EXE=[ON|OFF]  Default: OFF
     If this option is on, the executable will be linked statically to all
-    libraries. This option is currently only valid for gcc.
+    libraries. On MSVC, this means that EditorConfig will be statically
+    linked to the executable. On GCC, this means all libraries (glibc and 
+    EditorConfig) are statically linked to the executable.
     e.g. cmake -DBUILD_STATICALLY_LINKED_EXE=ON .
 
     -DINSTALL_HTML_DOC=[ON|OFF]             Default: OFF

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif(CMAKE_COMPILER_IS_GNUCC)
 
 option(BUILD_STATICALLY_LINKED_EXE
-    "Link the standard library statically when building the executable.(Only valid for gcc)"
+    "Statically link all libraries when building the executable."
     ${BUILD_STATICALLY_LINKED_EXE_DEFAULT_VAL})
 
 if(CMAKE_COMPILER_IS_GNUCC)
@@ -47,7 +47,11 @@ set(editorconfig_BINSRCS
 
 # targets
 add_executable(editorconfig_bin ${editorconfig_BINSRCS})
-target_link_libraries(editorconfig_bin editorconfig_static)
+if(BUILD_STATICALLY_LINKED_EXE)
+    target_link_libraries(editorconfig_bin editorconfig_static)
+else(BUILD_STATICALLY_LINKED_EXE)
+    target_link_libraries(editorconfig_bin editorconfig_shared)
+endif(BUILD_STATICALLY_LINKED_EXE)
 set_target_properties(editorconfig_bin PROPERTIES
     OUTPUT_NAME editorconfig
     VERSION


### PR DESCRIPTION
Fix build error where ld links static executable with dynamic library.
Make dynamic linking default
Update all Comments/Doc for new dynamic library behavior.
Update all Text