### PR TITLE
Consistently use GNUInstallDirs everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set (editorconfig_VERSION_SUFFIX "-development")
 
 project(editorconfig C)
 
+include(GNUInstallDirs)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake_Modules")
 
 # set default compilation directory

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -107,17 +107,17 @@ if(BUILD_DOCUMENTATION)
         # we need to exclude it when installing man3. Same for
         # editorconfig-format.3
         install(DIRECTORY ${EC_MANPAGE3_DIR}
-            DESTINATION share/man
+            DESTINATION "${CMAKE_INSTALL_MANDIR}"
             PATTERN editorconfig.3 EXCLUDE
             PATTERN editorconfig-format.3 EXCLUDE
             REGEX ._include_. EXCLUDE)
 
         install(FILES
             ${EC_MANPAGE1_DIR}/editorconfig.1
-            DESTINATION share/man/man1)
+            DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
         install(FILES
             ${EC_MANPAGE5_DIR}/editorconfig-format.5
-            DESTINATION share/man/man5)
+            DESTINATION "${CMAKE_INSTALL_MANDIR}/man5")
 
         # "make clean" should also clean generated docs
         set_directory_properties(PROPERTIES
@@ -125,7 +125,7 @@ if(BUILD_DOCUMENTATION)
 
         if(INSTALL_HTML_DOC)
             install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html"
-                DESTINATION share/doc/editorconfig)
+                DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/editorconfig")
         endif(INSTALL_HTML_DOC)
 
     else(DOXYGEN_FOUND)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -27,5 +27,5 @@
 install(FILES
     editorconfig/editorconfig.h
     editorconfig/editorconfig_handle.h
-    DESTINATION include/editorconfig)
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/editorconfig")
 

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -58,5 +58,5 @@ set_target_properties(editorconfig_bin PROPERTIES
     ${editorconfig_VERSION_MAJOR}.${editorconfig_VERSION_MINOR}.${editorconfig_VERSION_PATCH})
 
 install(TARGETS editorconfig_bin
-    RUNTIME DESTINATION bin)
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -24,8 +24,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-include(GNUInstallDirs)
-
 set(editorconfig_LIBSRCS
     ec_glob.c
     editorconfig.c


### PR DESCRIPTION
i.e. for installed headers, documentation and executables.