### PR TITLE
replace link to ArchLinux AUR package

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ Windows users can also install EditorConfig core by [Chocolatey](http://chocolat
 
 Debian (Jessie and later): `apt-get install editorconfig`
 
-ArchLinux: An [Arch AUR package](https://aur.archlinux.org/packages/editorconfig-core-c) is available.
+ArchLinux: `pacman -S editorconfig-core-c`
 
 Mac OS X users can `brew install editorconfig` with [Homebrew](http://brew.sh).
 Generally Linux users can also install with [LinuxBrew](https://github.com/Homebrew/linuxbrew)


### PR DESCRIPTION
It looks like the package has been migrated to the official Extra repository:

https://www.archlinux.org/packages/extra/x86_64/editorconfig-core-c/ 

so pacman (the official package manager) can be used to install the package.