### PR TITLE
Fix pkg-config include path

### DIFF
--- a/src/lib/editorconfig.pc.in
+++ b/src/lib/editorconfig.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/editorconfig
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
  
 Name: editorconfig
 Description: Library handling EditorConfig files, a file format defining coding styles in projects.


### PR DESCRIPTION
I didn't realized that the correct way to include the library is to specify `editorconfig/*.h`