### PR TITLE
CMake: Fix config file include target exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,19 +24,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-cmake_minimum_required(VERSION 2.8.12)
-cmake_policy(VERSION 2.8.12)
-# project() command sets VERSION variables (since CMake 3.0).
-cmake_policy(SET CMP0048 NEW)
+cmake_minimum_required(VERSION 3.5.1)
 
-project(editorconfig C)
-
-# Must be placed after the call to project().
-set(PROJECT_VERSION_MAJOR 0)
-set(PROJECT_VERSION_MINOR 12)
-set(PROJECT_VERSION_PATCH 4)
-set(PROJECT_VERSION
-    "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+project(editorconfig VERSION "0.12.4" LANGUAGES C)
 
 set(PROJECT_VERSION_SUFFIX "-development")
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -33,6 +33,9 @@ set(editorconfig_LIBSRCS
     )
 
 add_library(editorconfig_shared SHARED ${editorconfig_LIBSRCS})
+target_include_directories(editorconfig_shared
+    INTERFACE $<INSTALL_INTERFACE:include>
+)
 set_target_properties(editorconfig_shared PROPERTIES
     OUTPUT_NAME editorconfig
     SOVERSION 0
@@ -45,6 +48,9 @@ endif()
 target_link_libraries(editorconfig_shared ${PCRE2_LIBRARIES})
 
 add_library(editorconfig_static STATIC ${editorconfig_LIBSRCS})
+target_include_directories(editorconfig_static
+    INTERFACE $<INSTALL_INTERFACE:include>
+)
 set_target_properties(editorconfig_static PROPERTIES
     OUTPUT_NAME editorconfig_static
     VERSION ${PROJECT_VERSION})


### PR DESCRIPTION
This export is required to make the package cmake-relocatable and
find headers correctly for all installation prefixes.