### PR TITLE
Set cmake policy to version 3.2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@
 #
 
 cmake_minimum_required(VERSION 3.5.1)
+cmake_policy(VERSION 3.2)
 
 project(editorconfig VERSION "0.12.4" LANGUAGES C)
 


### PR DESCRIPTION
CMake 3.3 seems starting using a different command for static linking,
which breaks our build. Before that is resolved, cmake policy version
3.2 will be used.