### PR TITLE
Correct the library linked in static build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
-# Copyright (c) 2011-2018 EditorConfig Team
+# Copyright (c) 2011-2019 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -25,7 +25,7 @@
 #
 
 cmake_minimum_required(VERSION 3.5.1)
-cmake_policy(VERSION 3.2)
+cmake_policy(VERSION 3.5.1)
 
 project(editorconfig VERSION "0.12.4" LANGUAGES C)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
-# Copyright (c) 2011-2012 EditorConfig Team
+# Copyright (c) 2011-2019 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -26,6 +26,14 @@
 
 include(CheckFunctionExists)
 include(CheckTypeSize)
+
+option(BUILD_STATICALLY_LINKED_EXE
+    "Statically link all libraries when building the executable. This will also disable shared library."
+    OFF)
+
+if(BUILD_STATICALLY_LINKED_EXE AND NOT WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+endif()
 
 find_package(PCRE2 REQUIRED)
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,16 +1,16 @@
 #
-# Copyright (c) 2011-2012 EditorConfig Team
+# Copyright (c) 2011-2019 EditorConfig Team
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice,
 #    this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -46,6 +46,11 @@ if(WIN32)
     target_link_libraries(editorconfig_shared Shlwapi)
 endif()
 target_link_libraries(editorconfig_shared ${PCRE2_LIBRARIES})
+if (BUILD_STATICALLY_LINKED_EXE)
+    # disable shared library build when static is enabled
+    set_target_properties(editorconfig_shared PROPERTIES
+        EXCLUDE_FROM_ALL 1)
+endif()
 
 add_library(editorconfig_static STATIC ${editorconfig_LIBSRCS})
 target_include_directories(editorconfig_static
@@ -71,11 +76,19 @@ set(editorconfig_CONFIG_EXPORT_NAME "${config_package_name}Targets")
 set(editorconfig_CONFIG_INSTALL_LIBDIR
     "${CMAKE_INSTALL_LIBDIR}/cmake/${config_package_name}")
 
-install(TARGETS editorconfig_shared editorconfig_static
+install(TARGETS editorconfig_static
     EXPORT ${editorconfig_CONFIG_EXPORT_NAME}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+if(NOT BUILD_STATICALLY_LINKED_EXE)
+    install(TARGETS editorconfig_shared
+        EXPORT ${editorconfig_CONFIG_EXPORT_NAME}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/editorconfig.pc.in


### PR DESCRIPTION
In static build, we should find the static pcre2 not the dynamic one.
For ease of maintenance, we also disable the shared library build when
static build is enabled.

Previously we escaped this error because CMake policy <= 3.2 does not
use full path to found linked library and thus the static pcre2 library
sneaks in.