### PR TITLE
Use lower case library name for shlwapi to fix cross compiling for Wi…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+- Fix cross compiling for Windows
+
 v0.12.4
 
 - Add Windows build scripts.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,6 @@
 Contributors to EditorConfig C Core:
 
 Hong Xu
+Ralf Habacker
 Trey Hunner
 William Swanson

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -43,7 +43,7 @@ set_target_properties(editorconfig_shared PROPERTIES
 
 # We need to link Shwapi since we use PathIsRelative
 if(WIN32)
-    target_link_libraries(editorconfig_shared Shlwapi)
+    target_link_libraries(editorconfig_shared shlwapi)
 endif()
 target_link_libraries(editorconfig_shared ${PCRE2_LIBRARIES})
 if (BUILD_STATICALLY_LINKED_EXE)
@@ -62,7 +62,7 @@ set_target_properties(editorconfig_static PROPERTIES
 
 # We need to link Shwapi since we use PathIsRelative
 if(WIN32)
-    target_link_libraries(editorconfig_static Shlwapi)
+    target_link_libraries(editorconfig_static shlwapi)
 endif()
 target_link_libraries(editorconfig_static ${PCRE2_LIBRARIES})
 

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -28,7 +28,7 @@
 #include "misc.h"
 
 #ifdef WIN32
-# include <Shlwapi.h>
+# include <shlwapi.h>
 #endif
 
 #if !defined(HAVE_STRCASECMP) && !defined(HAVE_STRICMP)


### PR DESCRIPTION
This commit is required to fix cross compiling for Windows on [obs](https://build.opensuse.org/package/show/windows:mingw:win32/mingw32-editorconfig-core-c).