### PR TITLE
build: Fix paths in pkg-config file with absolute CMAKE_INSTALL_*

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -90,6 +90,16 @@ if(NOT BUILD_STATICALLY_LINKED_EXE)
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
+if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+    set(libdir_for_pc_file "${CMAKE_INSTALL_LIBDIR}")
+else()
+    set(libdir_for_pc_file "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+endif()
+if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(includedir_for_pc_file "${CMAKE_INSTALL_INCLUDEDIR}")
+else()
+    set(includedir_for_pc_file "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/editorconfig.pc.in
     ${CMAKE_CURRENT_BINARY_DIR}/editorconfig.pc

--- a/src/lib/editorconfig.pc.in
+++ b/src/lib/editorconfig.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
  
 Name: editorconfig
 Description: Library handling EditorConfig files, a file format defining coding styles in projects.


### PR DESCRIPTION
It is not generally true that `CMAKE_INSTALL_<dir>` variables are relative paths:

https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files

This lead to paths like `includedir=/nix/store/fgyha5n6mhknafwdharz9a5745wy6isn-editorconfig-core-c-0.12.5//nix/store/fgyha5n6mhknafwdharz9a5745wy6isn-editorconfig-core-c-0.12.5/include` in the pkg-config file, breaking builds.
