### PR TITLE
correct appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,19 @@
 image:
-  - Visual Studio 2017
+  - Visual Studio 2022
   
 environment:
   CONFIG: Release
-  VSVER: 15
+  VSVER: 17
   matrix:
     - ARCH: x86
     - ARCH: x64
+    #- ARCH: arm64
 
 install:
   - cmake --version
   - git submodule update --init
   # Download PCRE2 sources
-  - ps: ./init.ps1 -pcre 10.32
+  - ps: ./init.ps1 -pcre "10.37"
   # Build and install PCRE2
   - ps: ./build.ps1 -proj pcre2 -config $env:CONFIG -arch $env:ARCH -vsver $env:VSVER -init -install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,5 @@ test_script:
 
 on_failure:
   - echo. && echo. && echo. && echo "Tests for editorconfig-core-c failed. Here is their detailed output:" && echo. && echo. && echo.
-  - type .\bin\x64-static\core\Testing\Temporary\LastTest.log
+  - cd .\bin\%ARCH%-static\core\Testing\Temporary\
+  - type LastTest.log

--- a/build.ps1
+++ b/build.ps1
@@ -16,7 +16,7 @@ param(
     [string] $arch = "x64",
     
 
-    [ValidateSet("15","14","12")]
+    [ValidateSet("17","16","15","14","12")]
     [int] $vsver = 15
 )
 
@@ -75,6 +75,12 @@ if ($init) {
     $gen = "Visual Studio "
 
     switch ($vsver) {
+        17 {
+            $gen += "17 2022"
+        }
+        16 {
+            $gen += "16 2019"
+        }
         15 {
             $gen += "15 2017"
         }

--- a/build.ps1
+++ b/build.ps1
@@ -12,11 +12,11 @@ param(
     [ValidateSet("Debug","Release")]
     [string] $config = "Release",
 
-    [ValidateSet("x86","x64")]
+    [ValidateSet("x86","x64","arm64")]
     [string] $arch = "x64",
     
 
-    [ValidateSet("17","16","15","14","12")]
+    [ValidateSet("17","16","15","14")]
     [int] $vsver = 15
 )
 
@@ -95,8 +95,15 @@ if ($init) {
         }
     }
 
+    $cmake_arch=""
     if($arch -eq "x64"){
-        $gen += " Win64"
+        $cmake_arch += "x64"
+    }
+    elseif($arch -eq "x86"){
+        $cmake_arch += "Win32"
+    }
+    elseif($arch -eq "arm64"){
+        $cmake_arch += "ARM64"
     }
 
     mkdir $dest -ErrorAction SilentlyContinue | Out-Null
@@ -106,14 +113,14 @@ if ($init) {
             pcre2 {
                 $BUILD_SHARED_LIBS = "ON"
                 if ($static -eq "ON"){ $BUILD_SHARED_LIBS = "OFF"}
-                exec { cmake -G "$gen" -DCMAKE_INSTALL_PREFIX="$PREFIX" -DPCRE2_STATIC_RUNTIME="$static" `
+                exec { cmake -G "$gen" -A $cmake_arch -DCMAKE_INSTALL_PREFIX="$PREFIX" -DPCRE2_STATIC_RUNTIME="$static" `
                     -DBUILD_SHARED_LIBS="$BUILD_SHARED_LIBS" -DPCRE2_BUILD_PCRE2GREP="OFF" -DPCRE2_BUILD_TESTS="OFF" `
                     "../../pcre2" }
             }
             core {
                 $MSVC_MD = "ON"
                 if ($static -eq "ON"){ $MSVC_MD = "OFF"}
-                exec { cmake -G "$gen" -DCMAKE_INSTALL_PREFIX="$PREFIX" -DMSVC_MD="$MSVC_MD" -DPCRE2_STATIC="$static" `
+                exec { cmake -G "$gen" -A $cmake_arch -DCMAKE_INSTALL_PREFIX="$PREFIX" -DMSVC_MD="$MSVC_MD" -DPCRE2_STATIC="$static" `
                     "../../../." }
             }
         }

--- a/init.ps1
+++ b/init.ps1
@@ -14,7 +14,7 @@ New-Item $dest -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
 #####################################################################
 # pcre
 #####################################################################
-$url = "https://ftp.pcre.org/pub/pcre/pcre2-$($pcre).zip"
+$url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$($pcre)/pcre2-$($pcre).zip"
 $output = "$dest\pcre-$($pcre).zip"
 
 "Downloading pcre2 v$pcre sources" | Write-Host -ForegroundColor DarkGreen

--- a/init.ps1
+++ b/init.ps1
@@ -1,5 +1,5 @@
 param(
-    $pcre="10.32"
+    $pcre="10.37"
 )
 
 $ErrorActionPreference="Stop"

--- a/test.ps1
+++ b/test.ps1
@@ -8,7 +8,7 @@ param(
     [ValidateSet("Debug","Release")]
     [string] $config = "Release",
 
-    [ValidateSet("x86","x64")]
+    [ValidateSet("x86","x64","arm64")]
     [string] $arch = "x64"
 )
 


### PR DESCRIPTION
- correct appveyor build by using new PCRE download site
- prepare for VS2019\VS2022

Questions:
- What about using newer VS version?
- What about using newer PCRE2 version. Current one is 10.40.