### PR TITLE
Disable timestamp generation in doxygen

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1279,7 +1279,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that


### PR DESCRIPTION
If Doxyfile contains HTML_TIMESTAMP = YES, Doxygen will add a timestamp to its generated documentation. To allow reproducible builds this should be disabled.

https://reproducible-builds.org/docs/timestamps/