### PR TITLE
doc: use CMAKE_INSTALL_DOCDIR for the html docs install path

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -125,7 +125,7 @@ if(BUILD_DOCUMENTATION)
 
         if(INSTALL_HTML_DOC)
             install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html"
-                DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/editorconfig")
+                DESTINATION "${CMAKE_INSTALL_DOCDIR}")
         endif(INSTALL_HTML_DOC)
 
     else(DOXYGEN_FOUND)


### PR DESCRIPTION
This both simplifies the CMake code and makes it easier for downstream projects to override this path. The default (when not specifying CMAKE_INSTALL_DOCDIR) is the same as before (it defaults to CMAKE_INSTALL_DATAROOTDIR/doc/editorconfig).

I had to manually move around the installed documentation files in the [HaikuPorts recipe](https://github.com/haikuports/haikuports/blob/beafe6a38fb0ee5f903e7816cecf7583d175c036/app-text/editorconfig-core-c/editorconfig_core_c-0.12.6.recipe#L77-L80) because of this, which wouldn't be necessary with this change.