### PR TITLE
Fix several stack buffer overflows and pointer overflows

### DIFF
--- a/src/lib/ec_glob.c
+++ b/src/lib/ec_glob.c
@@ -192,10 +192,14 @@ int ec_glob(const char *pattern, const char *string)
                     if (!right_bracket)  /* The right bracket may not exist */
                         right_bracket = c + strlen(c);
 
-                    strcat(p_pcre, "\\");
+                    STRING_CAT(p_pcre, "\\", pcre_str_end);
+                    /* Boundary check for strncat below. */
+                    if (pcre_str_end - p_pcre <= right_bracket - c) {
+                        return -1;
+                    }
                     strncat(p_pcre, c, right_bracket - c);
                     if (*right_bracket)  /* right_bracket is a bracket */
-                        strcat(p_pcre, "\\]");
+                        STRING_CAT(p_pcre, "\\]", pcre_str_end);
                     p_pcre += strlen(p_pcre);
                     c = right_bracket;
                     if (!*c)
@@ -339,7 +343,7 @@ int ec_glob(const char *pattern, const char *string)
         }
     }
 
-    *(p_pcre ++) = '$';
+    ADD_CHAR(p_pcre, '$', pcre_str_end);
 
     pcre2_code_free(re); /* ^\\d+\\.\\.\\d+$ */
 

--- a/src/lib/ec_glob.c
+++ b/src/lib/ec_glob.c
@@ -27,6 +27,7 @@
 
 #include "global.h"
 
+#include <assert.h>
 #include <ctype.h>
 #include <string.h>
 #include <pcre2.h>
@@ -51,7 +52,8 @@ static const UT_icd ut_int_pair_icd = {sizeof(int_pair),NULL,NULL,NULL};
 /* concatenate the string then move the pointer to the end */
 #define STRING_CAT(p, string, end)  do {    \
     size_t string_len = strlen(string); \
-    if (p + string_len >= end) \
+    assert(end > p); \
+    if (string_len >= (size_t)(end - p)) \
         return -1; \
     strcat(p, string); \
     p += string_len; \


### PR DESCRIPTION
Several overflows may occur in switch `case '['` when the input pattern contains many escaped characters. The added backslashes leave too little space in the output pattern when processing nested brackets such that the remaining input length exceeds the output capacity. Therefore all these concatenations must also be checked.

The `ADD_CHAR` was missed in 41281ea (#87). The switch can exit exactly at capacity, leaving no room for the finishing `'$'`, causing an overflow.

In `STRING_CAT`, the end pointer is positioned one past the end of the destination, and it is undefined behavior to compute an address beyond the end pointer, including for comparisons, even temporarily. The UB occurs exactly when buffer overflow would have occurred, so the buffer overflow check could be optimized away by compilers. Even if this wasn't the case, the check could produce a false negative if the computed address overflowed the address space, which is, after all, why the C standard doesn't define behavior in the first place.

The fix is simple: Check using sizes, not addresses. The explicit cast suppresses warnings around signed-unsigned comparisons. It would also be worthwhile to `assert(end > p)`, which would have caught some of these issues sooner, but there is no established assertion discipline and I didn't want to introduce it here.

* * *

These issues were discovered with this quick-and-dirty afl fuzz target:

```c
#define _GNU_SOURCE
#define PCRE2_CODE_UNIT_WIDTH 8
#define UNIX
#define EC_VERSION_SUFFIX ""
#define EC_VERSION_MAJOR 0
#define EC_VERSION_MINOR 0
#define EC_VERSION_PATCH 0
#include "src/lib/ec_glob.c"
#include "src/lib/editorconfig.c"
#include "src/lib/ini.c"
#include "src/lib/misc.c"
#include <unistd.h>
#include <sys/mman.h>

__AFL_FUZZ_INIT();

int main(void)
{
    __AFL_INIT();
    int fd = memfd_create("fuzz", 0);
    unsigned char *buf = __AFL_FUZZ_TESTCASE_BUF;
    while (__AFL_LOOP(10000)) {
        int len = __AFL_FUZZ_TESTCASE_LEN;
        ftruncate(fd, 0);
        write(fd, buf, len);
        struct editorconfig_handle ec = {0};
        ec.conf_file_name = (char[]){'0'+fd, 0};
        editorconfig_parse("/proc/self/fd/", &ec);
    }
}
```

The interface only accepts input through a file path, which makes testing a bit more complex. `memfd_create()` avoids writing fuzz input through a real file and allows for parallel fuzzing because the virtual file path is private. I built and ran it like so:

    $ echo >include/config.h
    $ afl-gcc-fast -Iinclude -g3 -fsanitize=address,undefined fuzz.c -lpcre2-8
    $ afl-fuzz -i tests/parser/comments.in -o fuzzout ./a.out

[overflow-input.txt](https://github.com/editorconfig/editorconfig-core-c/files/14320240/overflow-input.txt) is an input that triggers all overflows addressed by these commits.
