### PR TITLE
Fix VS warnings C4701 and C4703; potentially uninitialized local (variable|pointer) used

### DIFF
--- a/src/lib/ec_glob.c
+++ b/src/lib/ec_glob.c
@@ -91,7 +91,7 @@ int ec_glob(const char *pattern, const char *string)
     pcre2_code *              re;
     int                       rc;
     size_t *                  pcre_result;
-    pcre2_match_data *        pcre_match_data;
+    pcre2_match_data *        pcre_match_data = NULL;
     char                      l_pattern[2 * PATTERN_MAX];
     _Bool                     are_braces_paired = 1;
     UT_array *                nums;     /* number ranges */


### PR DESCRIPTION
Fix VisualStudio 2022 warnings C4701 and C4703; potentially uninitialized local (variable|pointer) used

Warnings introduced by commit 02ac2b7652ca61630d0550f3977b5d59a18f5908.