### PR TITLE
GHA update 

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -19,7 +19,7 @@ jobs:
         submodules: recursive
 
     - name: Download PCRE2 sources
-      run: ./init.ps1 -pcre "10.40"
+      run: ./init.ps1 -pcre "10.45"
 
     - name: Build and install PCRE2
       run: ./build.ps1 -proj pcre2 -config ${{ matrix.build_configuration }} -arch ${{ matrix.build_platform }} -vsver ${{ matrix.build_vsver }} -init -install
@@ -31,12 +31,12 @@ jobs:
       if: matrix.build_platform == 'x86' || matrix.build_platform == 'x64'
       run: ./test.ps1 -proj core -config ${{ matrix.build_configuration }} -arch ${{ matrix.build_platform }}
 
-    - uses: olegtarasov/get-tag@v2.1.3
+    - uses: olegtarasov/get-tag@v2.1.4
       id: tagName
 
     - name: zip artifacts for ${{ matrix.build_platform }}
       if: matrix.build_configuration == 'Release'
-      run: 7z a editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip .\bin\${{ matrix.build_platform }}-static\build\
+      run: 7z a editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip .\bin\${{ matrix.build_platform }}-static\build\*
 
     - name: Archive artifacts for ${{ matrix.build_platform }}
       if: matrix.build_configuration == 'Release'
@@ -60,8 +60,8 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { compiler: GNU,  CC: gcc-11,   CXX: g++-11 }
-          - { compiler: LLVM, CC: clang-14, CXX: clang++-14 }
+          - { compiler: GNU,  CC: gcc-12,   CXX: g++-12 }
+          - { compiler: LLVM, CC: clang-15, CXX: clang++-15 }
         build_configuration: [Release, Debug]
         build_platform: ["Unix Makefiles"]
 

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -31,25 +31,25 @@ jobs:
       if: matrix.build_platform == 'x86' || matrix.build_platform == 'x64'
       run: ./test.ps1 -proj core -config ${{ matrix.build_configuration }} -arch ${{ matrix.build_platform }}
 
-    - uses: olegtarasov/get-tag@v2.1.4
-      id: tagName
+    - name: Get short SHA
+      run: echo "SHORT_SHA=$("${{ github.sha }}".SubString(0, 8))" >> $env:GITHUB_ENV
 
-    - name: zip artifacts for ${{ matrix.build_platform }}
+    - name: zip artifacts for ${{ matrix.build_platform }} on ${{ github.ref_name }} with sha ${{ github.sha }}
       if: matrix.build_configuration == 'Release'
-      run: 7z a editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip .\bin\${{ matrix.build_platform }}-static\build\*
+      run: 7z a editorconfig-core-c_${{ github.ref_name }}_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip .\bin\${{ matrix.build_platform }}-static\build\*
 
     - name: Archive artifacts for ${{ matrix.build_platform }}
       if: matrix.build_configuration == 'Release'
       uses: actions/upload-artifact@v4
       with:
-          name: editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip
-          path: editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip
+          name: editorconfig-core-c_${{ github.ref_name }}_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip
+          path: editorconfig-core-c_${{ github.ref_name }}_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip
 
     - name: Create release on tagging
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-          files: editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip
+          files: editorconfig-core-c_${{ github.ref_name }}_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip
 
 
 
@@ -60,8 +60,8 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { compiler: GNU,  CC: gcc-12,   CXX: g++-12 }
-          - { compiler: LLVM, CC: clang-15, CXX: clang++-15 }
+          - { compiler: GNU,  CC: gcc-11,   CXX: g++-11 }
+          - { compiler: LLVM, CC: clang-14, CXX: clang++-14 }
         build_configuration: [Release, Debug]
         build_platform: ["Unix Makefiles"]
 

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -31,25 +31,28 @@ jobs:
       if: matrix.build_platform == 'x86' || matrix.build_platform == 'x64'
       run: ./test.ps1 -proj core -config ${{ matrix.build_configuration }} -arch ${{ matrix.build_platform }}
 
+    - uses: olegtarasov/get-tag@v2.1.4
+      id: tagName
+
     - name: Get short SHA
       run: echo "SHORT_SHA=$("${{ github.sha }}".SubString(0, 8))" >> $env:GITHUB_ENV
 
     - name: zip artifacts for ${{ matrix.build_platform }} on ${{ github.ref_name }} with sha ${{ github.sha }}
       if: matrix.build_configuration == 'Release'
-      run: 7z a editorconfig-core-c_${{ github.ref_name }}_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip .\bin\${{ matrix.build_platform }}-static\build\*
+      run: 7z a editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip .\bin\${{ matrix.build_platform }}-static\build\*
 
     - name: Archive artifacts for ${{ matrix.build_platform }}
       if: matrix.build_configuration == 'Release'
       uses: actions/upload-artifact@v4
       with:
-          name: editorconfig-core-c_${{ github.ref_name }}_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip
-          path: editorconfig-core-c_${{ github.ref_name }}_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip
+          name: editorconfig-core-c_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip
+          path: editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip
 
     - name: Create release on tagging
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-          files: editorconfig-core-c_${{ github.ref_name }}_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip
+          files: editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip
 
 
 

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -58,13 +58,13 @@ jobs:
 
   build_linux:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         compiler:
-          - { compiler: GNU,  CC: gcc-11,   CXX: g++-11 }
-          - { compiler: LLVM, CC: clang-14, CXX: clang++-14 }
+          - { compiler: GNU,  CC: gcc-14,   CXX: g++-14 }
+          - { compiler: LLVM, CC: clang-18, CXX: clang++-18 }
         build_configuration: [Release, Debug]
         build_platform: ["Unix Makefiles"]
 

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: windows-2022
     strategy:
-      max-parallel: 6
+      fail-fast: false
       matrix:
         build_configuration: [Release, Debug]
         build_platform: [x64, arm64, x86]
@@ -31,11 +31,33 @@ jobs:
       if: matrix.build_platform == 'x86' || matrix.build_platform == 'x64'
       run: ./test.ps1 -proj core -config ${{ matrix.build_configuration }} -arch ${{ matrix.build_platform }}
 
+    - uses: olegtarasov/get-tag@v2.1.3
+      id: tagName
+
+    - name: zip artifacts for ${{ matrix.build_platform }}
+      if: matrix.build_configuration == 'Release'
+      run: 7z a editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip .\bin\${{ matrix.build_platform }}-static\build\
+
+    - name: Archive artifacts for ${{ matrix.build_platform }}
+      if: matrix.build_configuration == 'Release'
+      uses: actions/upload-artifact@v4
+      with:
+          name: editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip
+          path: editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip
+
+    - name: Create release on tagging
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+          files: editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip
+
+
+
   build_linux:
 
     runs-on: ubuntu-22.04
     strategy:
-      max-parallel: 4
+      fail-fast: false
       matrix:
         compiler:
           - { compiler: GNU,  CC: gcc-11,   CXX: g++-11 }
@@ -57,6 +79,36 @@ jobs:
       env:
         CC: ${{ matrix.compiler.CC }}
         CXX: ${{ matrix.compiler.CXX }}
+      run: |
+           mkdir _build
+           cd _build
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_INSTALL_PREFIX=../_install ..
+
+    - name: build cmake
+      run: |
+           cd _build
+           cmake --build . --config ${{ matrix.build_configuration }} --target install
+
+    - name: run tests
+      run: |
+           cd _build
+           ctest -VV --output-on-failure .
+
+  build_macos:
+
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_configuration: [Release, Debug]
+        build_platform: ["Unix Makefiles"]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: generate cmake
       run: |
            mkdir _build
            cd _build

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -31,28 +31,25 @@ jobs:
       if: matrix.build_platform == 'x86' || matrix.build_platform == 'x64'
       run: ./test.ps1 -proj core -config ${{ matrix.build_configuration }} -arch ${{ matrix.build_platform }}
 
-    - uses: olegtarasov/get-tag@v2.1.4
-      id: tagName
-
     - name: Get short SHA
       run: echo "SHORT_SHA=$("${{ github.sha }}".SubString(0, 8))" >> $env:GITHUB_ENV
 
     - name: zip artifacts for ${{ matrix.build_platform }} on ${{ github.ref_name }} with sha ${{ github.sha }}
       if: matrix.build_configuration == 'Release'
-      run: 7z a editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip .\bin\${{ matrix.build_platform }}-static\build\*
+      run: 7z a editorconfig-core-c_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip .\bin\${{ matrix.build_platform }}-static\build\*
 
     - name: Archive artifacts for ${{ matrix.build_platform }}
       if: matrix.build_configuration == 'Release'
       uses: actions/upload-artifact@v4
       with:
           name: editorconfig-core-c_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip
-          path: editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip
+          path: editorconfig-core-c_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip
 
     - name: Create release on tagging
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-          files: editorconfig-core-c_${{ steps.tagName.outputs.tag }}_${{ matrix.build_platform }}.zip
+          files: editorconfig-core-c_${{ env.SHORT_SHA }}_${{ matrix.build_platform }}.zip
 
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,7 +126,7 @@ Download pcre2
 You have to download and extract the pcre2 sources after checkout.
 
 ```powershell
-~> ./init.ps1 [-pcre "10.40"]
+~> ./init.ps1 [-pcre "10.45"]
 ```
 
 Arguments:

--- a/init.ps1
+++ b/init.ps1
@@ -1,5 +1,5 @@
 param(
-    $pcre="10.40"
+    $pcre="10.45"
 )
 
 $ErrorActionPreference="Stop"


### PR DESCRIPTION
- publishing of windows build folder on CI builds and for releases, related to discussion at https://github.com/editorconfig/editorconfig-core-c/issues/39
- added macos build job
- pcre2 10.40 updated to 10.45 for windows builds

Open topics:
- what should be published? Starting point here is the complete build folder, see artifacts at https://github.com/editorconfig/editorconfig-core-c/actions/runs/13712822017