### PR TITLE
Replace custom MSVC_MD option with standard CMAKE_MSVC_RUNTIME_LIBRARY.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -86,13 +86,6 @@ could be used when generating the project file:
     documentation, try to set this option to the path to doxygen.
     e.g. cmake -DDOXYGEN_EXECUTABLE=/opt/doxygen/bin/doxygen .
 
-    -DMSVC_MD=[ON|OFF]                      Default: OFF
-    Use /MD instead of /MT flag when compiling with Microsoft Visual C++. This
-    option takes no effect when using compilers other than Microsoft Visual
-    C++. Note that the option chosen here must be consistent with PCRE2.
-    e.g. We want to use /MD instead of /MT when compiling with MSVC.
-    cmake -DMSVC_MD=ON .
-
 On UNIX/Linux with gcc, the project file is often a Makefile, in which case you
 can type "make" to compile editorconfig.  If you are using a different compiler
 or platform the compilation command may differ. For example, if you generate an

--- a/build.ps1
+++ b/build.ps1
@@ -109,16 +109,16 @@ if ($init) {
     mkdir $dest -ErrorAction SilentlyContinue | Out-Null
     Push-Location $dest
     try {
+        $MsvcRuntime = if($static -eq "ON") { "MultiThreaded" } else { "MultiThreadedDLL" }
         switch ($proj) {
             pcre2 {
                 $BUILD_SHARED_LIBS = "ON"
                 if ($static -eq "ON"){ $BUILD_SHARED_LIBS = "OFF"}
-                exec { cmake -G "$gen" -A $cmake_arch -DCMAKE_INSTALL_PREFIX="$PREFIX" -DPCRE2_STATIC_RUNTIME="$static" `
+                exec { cmake -G "$gen" -A $cmake_arch -DCMAKE_INSTALL_PREFIX="$PREFIX" -DPCRE2_STATIC_RUNTIME="$static" -DCMAKE_MSVC_RUNTIME_LIBRARY="$MsvcRuntime" `
                     -DBUILD_SHARED_LIBS="$BUILD_SHARED_LIBS" -DPCRE2_BUILD_PCRE2GREP="OFF" -DPCRE2_BUILD_TESTS="OFF" `
                     "../../pcre2" }
             }
             core {
-                $MsvcRuntime = if($static -eq "ON") { "MultiThreaded" } else { "MultiThreadedDLL" }
                 exec { cmake -G "$gen" -A $cmake_arch -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_MSVC_RUNTIME_LIBRARY="$MsvcRuntime" -DPCRE2_STATIC="$static" "../../../." }
             }
         }

--- a/build.ps1
+++ b/build.ps1
@@ -118,10 +118,8 @@ if ($init) {
                     "../../pcre2" }
             }
             core {
-                $MSVC_MD = "ON"
-                if ($static -eq "ON"){ $MSVC_MD = "OFF"}
-                exec { cmake -G "$gen" -A $cmake_arch -DCMAKE_INSTALL_PREFIX="$PREFIX" -DMSVC_MD="$MSVC_MD" -DPCRE2_STATIC="$static" `
-                    "../../../." }
+                $MsvcRuntime = if($static -eq "ON") { "MultiThreaded" } else { "MultiThreadedDLL" }
+                exec { cmake -G "$gen" -A $cmake_arch -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_MSVC_RUNTIME_LIBRARY="$MsvcRuntime" -DPCRE2_STATIC="$static" "../../../." }
             }
         }
     } finally {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,24 +62,6 @@ configure_file(
 include_directories(BEFORE
     "${PROJECT_SOURCE_DIR}/include")
 
-if(WIN32)
-    # MSVC_MD option
-    option(MSVC_MD
-        "Use /MD instead of /MT flag when compiling with Microsoft Visual C++. This option takes no effect when using compilers other than Microsoft Visual C++."
-        OFF)
-endif()
-
-# replace all /MD with /MT for msvc if MSVC_MD is off
-if(MSVC AND NOT MSVC_MD)
-    foreach(flag_var
-            CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-            CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
-        if(${flag_var} MATCHES "/MD")
-            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-        endif(${flag_var} MATCHES "/MD")
-    endforeach(flag_var)
-endif()
-
 # Use unsigned char to represent plain char
 if(MSVC)
     add_definitions("-J")


### PR DESCRIPTION
Instead of replacing /MD with /MT via search-and-replace, we now make use of the standard CMAKE_MSVC_RUNTIME_LIBRARY option when building with the build.ps1 script.

The CMAKE_MSVC_RUNTIME_LIBRARY option is supported since CMake 3.15 and the root CMakeLists.txt file states CMake 3.16.3 as the minimum version, so using this option should not be a problem.

I encountered a linker warning stating that the MSVC runtime libraries used don't match up. It turned out PCRE2 was linking the static MSVCRT statically and the `MSVC_MD` mechanism did not work, but the resulting editorconfig_static.lib still ended up linking the MSVC runtime library dynamically. After debugging with some `message(...)` calls inserted, it turns out there was no `/MD` string present in any of the listed options (i.e. `CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO` see the old src/CMakeLists.txt lines 75 and 76), so it never got around to inserting `/MT` there. I assume CMake defaults changed at some point to no insert `/MD` by default but rather insert it at a later stage before passing it to the compiler, probably based on the `CMAKE_MSVC_RUNTIME_LIBRARY` option. However, I did not dig into this further, so this is all just speculation.

Digging through CMake legacy stuff is always so time consuming and this seemed like an obvious solution for the min supported CMake version AND it worked for me, so I figured I'd share this in the form of a PR. Please reject this PR if you feel that more investigation needs to be done to make sure the `MSVC_MD` option truly is defective.