### PR TITLE
docs: Fix initialize word wrote with error on comment

### DIFF
--- a/include/editorconfig/editorconfig_handle.h
+++ b/include/editorconfig/editorconfig_handle.h
@@ -50,7 +50,7 @@ extern "C" {
 typedef void*   editorconfig_handle;
 
 /*!
- * @brief Create and intialize a default editorconfig_handle object.
+ * @brief Create and initialize a default editorconfig_handle object.
  *
  * @retval NULL Failed to create the editorconfig_handle object.
  *


### PR DESCRIPTION
Hi, I'm packaging this project on debian and my lintian returned a warning with this word, sending a small PR to fix it, ty =)