### PR TITLE
Generate output directories before building manpages

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -71,6 +71,8 @@ if(BUILD_DOCUMENTATION)
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/man/man1/editorconfig.1
             COMMAND
+            ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/man
+            COMMAND
             ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile-1"
             MAIN_DEPENDENCY
             ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
@@ -87,6 +89,8 @@ if(BUILD_DOCUMENTATION)
 
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/man/man5/editorconfig-format.5
+            COMMAND
+            ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/man
             COMMAND
             ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile-5"
             MAIN_DEPENDENCY


### PR DESCRIPTION
Otherwise, there is a race when the two manpages are generated, and the
build might intermittently fail with errors like this:

error: Could not create output directory /home/abuild/rpmbuild/BUILD/editorconfig-core-c-0.12.9-build/editorconfig-core-c-0.12.9/build/doc/man
make[2]: *** [doc/CMakeFiles/doc.dir/build.make:91: doc/man/man5/editorconfig-format.5] Error 1
