### PR TITLE
Add display_exclude_patterns and index_exclude_patterns properties

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
-v0.12.10
+v0.12.11
 
+- Add `display_exclude_patterns` and `index_exclude_patterns` properties to allow excluding files from display and search indexing. (Fixes #228)
+- Add tests for new properties.
+
+v0.12.10
 - Make path splitting algorithm UNC-aware (#135)
 - Update utarray.h to 2.3.0 (#137)
 - Miscellaneous fixes.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,7 @@
-v0.12.11
+v0.12.10
 
 - Add `display_exclude_patterns` and `index_exclude_patterns` properties to allow excluding files from display and search indexing. (Fixes #228)
 - Add tests for new properties.
-
-v0.12.10
 - Make path splitting algorithm UNC-aware (#135)
 - Update utarray.h to 2.3.0 (#137)
 - Miscellaneous fixes.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,11 +111,17 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt)
         # Used by tests/CMakeLists.txt.
     add_subdirectory(tests)
 
-    # Test for new exclude properties
-    add_test(NAME exclude_properties_test
+    # Test for new exclude properties - display_exclude_patterns
+    add_test(NAME exclude_properties_display_test
         COMMAND editorconfig_bin -f ${CMAKE_CURRENT_SOURCE_DIR}/test_exclude/.editorconfig ${CMAKE_CURRENT_SOURCE_DIR}/test_exclude/dummy.txt
     )
-    set_tests_properties(exclude_properties_test PROPERTIES PASS_REGULAR_EXPRESSION "display_exclude_patterns=.*\\nindex_exclude_patterns=.*")
+    set_tests_properties(exclude_properties_display_test PROPERTIES PASS_REGULAR_EXPRESSION "display_exclude_patterns=\*\.min\.js, \*\.log")
+
+    # Test for new exclude properties - index_exclude_patterns
+    add_test(NAME exclude_properties_index_test
+        COMMAND editorconfig_bin -f ${CMAKE_CURRENT_SOURCE_DIR}/test_exclude/.editorconfig ${CMAKE_CURRENT_SOURCE_DIR}/test_exclude/dummy.txt
+    )
+    set_tests_properties(exclude_properties_index_test PROPERTIES PASS_REGULAR_EXPRESSION "index_exclude_patterns=\*\.o, build/")
     message(STATUS "Tests enabled")
 else()
     message(WARNING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,12 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt)
         # rather than an executable file named "editorconfig_bin".
         # Used by tests/CMakeLists.txt.
     add_subdirectory(tests)
+
+    # Test for new exclude properties
+    add_test(NAME exclude_properties_test
+        COMMAND editorconfig_bin -f ${CMAKE_CURRENT_SOURCE_DIR}/test_exclude/.editorconfig ${CMAKE_CURRENT_SOURCE_DIR}/test_exclude/dummy.txt
+    )
+    set_tests_properties(exclude_properties_test PROPERTIES PASS_REGULAR_EXPRESSION "display_exclude_patterns=.*\\nindex_exclude_patterns=.*")
     message(STATUS "Tests enabled")
 else()
     message(WARNING

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Hong Xu
 Ralf Habacker
 Trey Hunner
 William Swanson
+shaidshark

--- a/include/editorconfig/editorconfig.h
+++ b/include/editorconfig/editorconfig.h
@@ -184,6 +184,8 @@
  * <li><strong>trim_trailing_whitespace</strong>:  set to "true" to remove any whitespace characters preceding newline characters and "false" to ensure it doesn't.</li>
  * <li><strong>insert_final_newline</strong>: set to "true" ensure file ends with a newline when saving and "false" to ensure it doesn't.</li>
  * <li><strong>root</strong>: special property that should be specified at the top of the file outside of any sections. Set to "true" to stop <code>.editorconfig</code> files search on current file. The value is case insensitive.</li>
+ * <li><strong>display_exclude_patterns</strong>: a comma-separated list of glob patterns specifying files and directories that should not be displayed in file trees or project views. Patterns are matched using the same rules as section names. This property is typically set in the <code>[ * ]</code> section to apply globally.</li>
+ * <li><strong>index_exclude_patterns</strong>: a comma-separated list of glob patterns specifying files and directories that should not be indexed or included in search results. Patterns are matched using the same rules as section names. This property is typically set in the <code>[ * ]</code> section to apply globally.</li>
  * </ul>
  *
  * For any property, a value of "unset" is to remove the effect of that

--- a/include/editorconfig/editorconfig.h
+++ b/include/editorconfig/editorconfig.h
@@ -184,8 +184,8 @@
  * <li><strong>trim_trailing_whitespace</strong>:  set to "true" to remove any whitespace characters preceding newline characters and "false" to ensure it doesn't.</li>
  * <li><strong>insert_final_newline</strong>: set to "true" ensure file ends with a newline when saving and "false" to ensure it doesn't.</li>
  * <li><strong>root</strong>: special property that should be specified at the top of the file outside of any sections. Set to "true" to stop <code>.editorconfig</code> files search on current file. The value is case insensitive.</li>
- * <li><strong>display_exclude_patterns</strong>: a comma-separated list of glob patterns specifying files and directories that should not be displayed in file trees or project views. Patterns are matched using the same rules as section names. This property is typically set in the <code>[ * ]</code> section to apply globally.</li>
- * <li><strong>index_exclude_patterns</strong>: a comma-separated list of glob patterns specifying files and directories that should not be indexed or included in search results. Patterns are matched using the same rules as section names. This property is typically set in the <code>[ * ]</code> section to apply globally.</li>
+ * <li><strong>display_exclude_patterns</strong>: a comma-separated list of glob patterns specifying files and directories that should not be displayed in file trees or project views. Patterns are matched using the same rules as section names. This property is typically set in the <code>[*]</code> section to apply globally.</li>
+ * <li><strong>index_exclude_patterns</strong>: a comma-separated list of glob patterns specifying files and directories that should not be indexed or included in search results. Patterns are matched using the same rules as section names. This property is typically set in the <code>[*]</code> section to apply globally.</li>
  * </ul>
  *
  * For any property, a value of "unset" is to remove the effect of that

--- a/test_exclude/.editorconfig
+++ b/test_exclude/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+display_exclude_patterns = *.min.js, *.log
+index_exclude_patterns = *.o, build/

--- a/test_exclude/dummy.txt
+++ b/test_exclude/dummy.txt
@@ -1,0 +1,1 @@
+This is a dummy file.


### PR DESCRIPTION
This PR adds two new properties to EditorConfig to support excluding files from display and search indexing.\n\nFixes #228